### PR TITLE
Added automatic system for Genshin Path detection and Reloading of Configs on app launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -361,4 +361,6 @@ MigrationBackup/
 
 # Fody - auto-generated XML schema
 FodyWeavers.xsd
+
 *.exe
+Notes.txt

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -31,7 +31,7 @@ namespace NeoHanega
             {
                 if (File.Exists(configPath + "\\config.json"))
                 {
-                    config = JsonSerializer.Deserialize<NeoHanegaConfig>(File.ReadAllText(configPath + "\\config.json"));
+                    config = JsonSerializer.Deserialize<NeoHanegaConfig>(File.ReadAllText(configPath + "\\config.json")) ?? new NeoHanegaConfig();
                     if (config != null)
                     {
                         if (File.Exists(config.genshinPath) && File.Exists(config.migotoPath))
@@ -40,7 +40,7 @@ namespace NeoHanega
                             {
                                 ProcessStartInfo migotoStart = new ProcessStartInfo();
                                 migotoStart.FileName = config.migotoPath;
-                                migotoStart.WorkingDirectory = System.IO.Directory.GetParent(config.migotoPath).FullName;
+                                migotoStart.WorkingDirectory = Directory.GetParent(config.migotoPath).FullName;
                                 Process.Start(migotoStart);
 
                                 String migotoProcessName = Path.GetFileName(config.migotoPath).Split('.')[0];

--- a/App.xaml.cs
+++ b/App.xaml.cs
@@ -24,18 +24,19 @@ namespace NeoHanega
     {
         private void Application_Startup(object sender, StartupEventArgs e)
         {
-            if (e.Args.Contains("--start")) 
+            string localAppdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+            string configPath = localAppdata + "\\NeoHanega";
+            NeoHanegaConfig config = new NeoHanegaConfig();
+            if (Directory.Exists(configPath))
             {
-                string localAppdata = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
-                string configPath = localAppdata + "\\NeoHanega";
-                if (Directory.Exists(configPath))
+                if (File.Exists(configPath + "\\config.json"))
                 {
-                    if (File.Exists(configPath + "\\config.json"))
+                    config = JsonSerializer.Deserialize<NeoHanegaConfig>(File.ReadAllText(configPath + "\\config.json"));
+                    if (config != null)
                     {
-                        NeoHanegaConfig config = JsonSerializer.Deserialize<NeoHanegaConfig>(File.ReadAllText(configPath + "\\config.json"));
-                        if (config != null)
+                        if (File.Exists(config.genshinPath) && File.Exists(config.migotoPath))
                         {
-                            if (File.Exists(config.genshinPath) && File.Exists(config.migotoPath))
+                            if (e.Args.Contains("--start"))
                             {
                                 ProcessStartInfo migotoStart = new ProcessStartInfo();
                                 migotoStart.FileName = config.migotoPath;
@@ -56,7 +57,20 @@ namespace NeoHanega
                     }
                 }
             }
-            MainWindow mainWindow = new MainWindow();
+
+            String genshinPath = null;
+            String migotoPath = null;
+
+            if(config.genshinPath != null)
+            {
+                genshinPath = config.genshinPath;
+            }
+            if(config.migotoPath != null)
+            {
+                migotoPath = config.migotoPath;
+            }
+
+            MainWindow mainWindow = new MainWindow(genshinPath, migotoPath);
             mainWindow.Show();  
         }
     }

--- a/GenshinFinder.cs
+++ b/GenshinFinder.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+
+namespace NeoHanega
+{
+    class GenshinFinder
+    {
+        public static void FindGenshin(Action<String?> callback)
+        {
+            Task.Run(() =>
+            {
+                String gamedataPath = Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData);
+                gamedataPath += "\\Cognosphere\\HYP\\1_0\\data";
+                if (!Directory.Exists(gamedataPath) || !File.Exists(gamedataPath + "\\gamedata.dat"))
+                {
+                    return;
+                }
+                String gamedata = File.ReadAllText(gamedataPath + "\\gamedata.dat");
+
+                var matches = Regex.Matches(gamedata, @"(\{(?:[^{}]|(?<open>\{)|(?<-open>\}))*?(?(open)(?!))\}|\[.*?\])");
+
+                foreach (Match match in matches)
+                {
+                    var obj = JsonSerializer.Deserialize<Dictionary<string, dynamic>>(match.Value);
+                    if (obj["gameShortcutName"].ToString().Equals("Genshin Impact"))
+                    {
+                        callback(obj["persistentInstallPath"].ToString());
+                        return;
+                    }
+                }
+            });
+           return;
+        }
+    }
+}

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -112,13 +112,13 @@ namespace NeoHanega
 
             if (removeUAC)
             {
-                RegistryKey key = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers", true);
+                RegistryKey? key = Registry.CurrentUser.OpenSubKey("Software\\Microsoft\\Windows NT\\CurrentVersion\\AppCompatFlags\\Layers", true);
                 if (key != null)
                 {
                     key.SetValue(genshinPath, "~ RUNASINVOKER", RegistryValueKind.String);
                     key.SetValue(migotoPath, "~ RUNASINVOKER", RegistryValueKind.String);
                 }
-                String migotoFolder = System.IO.Directory.GetParent(migotoPath).FullName;
+                String migotoFolder = Directory.GetParent(migotoPath).FullName;
                 String migotoConfig = migotoFolder + "\\d3dx.ini";
                 if (!File.Exists(migotoConfig))
                 {
@@ -140,7 +140,7 @@ namespace NeoHanega
 
             string deskDir = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
 
-            string exePath = Environment.ProcessPath;
+            string exePath = Environment.ProcessPath ?? "";
             string shortcutPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\Launch NeoHanega.lnk";
 
             IWshRuntimeLibrary.WshShell shell = new IWshRuntimeLibrary.WshShell();

--- a/MainWindow.xaml.cs
+++ b/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Navigation;
 using System.Windows.Shapes;
+using static NeoHanega.GenshinFinder;
 
 namespace NeoHanega
 {
@@ -24,29 +25,58 @@ namespace NeoHanega
         private String? migotoPath;
         private bool removeUAC = false;
 
-        public MainWindow()
+        public MainWindow(String? genshinPath, String? migotoPath)
         {
             InitializeComponent();
+            if (genshinPath == null)
+            {
+                GenshinFinder.FindGenshin(updateGenshinPath);
+            } else
+            {
+                this.genshinPath = genshinPath;
+                this.migotoPath = migotoPath;
+            }
+
+            genshinpath_textbox.Text = genshinPath;
+            migotopath_textbox.Text = migotoPath;
+        }
+
+        private void updateGenshinPath(String? path)
+        {
+            if(path != null)
+            {
+                Application.Current.Dispatcher.Invoke(() =>
+                {
+                    genshinPath = path += "\\GenshinImpact.exe";
+                    genshinpath_textbox.Text = genshinPath;
+                });
+            }
         }
 
         private void migotoselect_button_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog migotoFileDialog = new OpenFileDialog();
-            migotoFileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+            migotoFileDialog.InitialDirectory = migotoPath != null ? migotoPath : Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
             migotoFileDialog.Filter = "3D Migoto Executable|3DMigoto Loader.exe|Any Executable|*.exe";
             migotoFileDialog.ShowDialog();
-            migotoPath = migotoFileDialog.FileName;
-            migotopath_textbox.Text = migotoFileDialog.FileName;
+            if (migotoFileDialog.FileName != "")
+            {
+                migotoPath = migotoFileDialog.FileName;
+                migotopath_textbox.Text = migotoFileDialog.FileName;
+            }
         }
 
         private void genshinselect_button_Click(object sender, RoutedEventArgs e)
         {
             OpenFileDialog genshinFileDialog = new OpenFileDialog();
-            genshinFileDialog.InitialDirectory = Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
+            genshinFileDialog.InitialDirectory = genshinPath != null ? genshinPath : Environment.GetFolderPath(Environment.SpecialFolder.Desktop);
             genshinFileDialog.Filter = "Genshin Impact Executable|GenshinImpact.exe|Any Executable|*.exe";
             genshinFileDialog.ShowDialog();
-            genshinPath = genshinFileDialog.FileName;
-            genshinpath_textbox.Text = genshinFileDialog.FileName;
+            if (genshinFileDialog.FileName != "")
+            {
+                genshinPath = genshinFileDialog.FileName;
+                genshinpath_textbox.Text = genshinFileDialog.FileName;
+            }
         }
 
         private void uac_checkbox_Checked(object sender, RoutedEventArgs e)
@@ -110,7 +140,7 @@ namespace NeoHanega
 
             string deskDir = Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory);
 
-            string exePath = System.Diagnostics.Process.GetCurrentProcess().MainModule.FileName;
+            string exePath = Environment.ProcessPath;
             string shortcutPath = Environment.GetFolderPath(Environment.SpecialFolder.Desktop) + "\\Launch NeoHanega.lnk";
 
             IWshRuntimeLibrary.WshShell shell = new IWshRuntimeLibrary.WshShell();

--- a/NeoHanega.csproj
+++ b/NeoHanega.csproj
@@ -8,14 +8,14 @@
     <UseWPF>true</UseWPF>
     <ApplicationIcon>Hanega.ico</ApplicationIcon>
     <PlatformTarget>x64</PlatformTarget>
-    <Version>1.1.0</Version>
+    <Version>1.1.5</Version>
     <Authors>ProsD</Authors>
     <Company>ProsD Industires</Company>
     <Title>NeoHanega</Title>
     <PackageProjectUrl>https://github.com/ProsD03/NeoHanega</PackageProjectUrl>
     <RepositoryUrl>https://github.com/ProsD03/NeoHanega</RepositoryUrl>
-    <AssemblyVersion>1.1.0</AssemblyVersion>
-    <FileVersion>1.1.0</FileVersion>
+    <AssemblyVersion>1.1.5</AssemblyVersion>
+    <FileVersion>1.1.5</FileVersion>
     <SignAssembly>False</SignAssembly>
     <Copyright>Copyright (C) 2024  ProsD</Copyright>
     <PackageLicenseFile>LICENSE.txt</PackageLicenseFile>


### PR DESCRIPTION
Added a system that automatically finds the Genshin Impact executable by reading it from HoyoLauncher appdata. The gamedata.dat file (at \AppData\Roaming\Cognosphere\HYP\1_0\data) contains JSON-encoded entries for each game installed: by searching which JSON contains the "gameShortcutName" value "Genshin Impact", the path to the game install folder can be found in the "persistentInstallPath" value.
Also added a system that reloads the config file when opening the program without the --start parameter, which shows the users the configured values.